### PR TITLE
Bump year & fix typo

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2018 kollavarsham.org
+Copyright (c) 2015-2021 kollavarsham.org
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ Postman Collection with example invocations: https://www.getpostman.com/collecti
 ##### [VS Code REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client)
 
 ```plain
-GET http://localhost:3000/api/years/2018
+GET http://localhost:3000/api/years/2021
 content-type: application/json
 ```

--- a/app.js
+++ b/app.js
@@ -68,7 +68,7 @@ module.exports = () => {
   const router = express.Router();              // get an instance of the express Router
 
   router.get('/', (req, res) => {
-    res.json({message : 'Welcome to Kollavarsham API!!1'});
+    res.json({message : 'Welcome to Kollavarsham API!!!'});
   });
 
   router.use('/', yearRouter);


### PR DESCRIPTION
- Bumped year in `LICENSE` and `README`
- Fixed typo in `app.js`